### PR TITLE
try/catch around JSON.parse

### DIFF
--- a/webpurify.js
+++ b/webpurify.js
@@ -73,7 +73,13 @@ WebPurify.prototype.request = function(host, path, method, ssl, callback) {
     }
     var req = base_type.request(options, function(res) {
         res.on('data', function(data) {
-            callback(null, JSON.parse(data));
+            try {
+                data = JSON.parse(data);
+            } catch (e) {
+                return callback("Invalid JSON");
+            }
+
+            callback(null, data);
         });
     });
     req.on('error', function(error) {


### PR DESCRIPTION
I've had occasional issues recently where the webpurify service would return HTML documents (server errors) in response to API requests. In those cases, JSON.parse would throw an exception and crash my application. I've added a try/catch around JSON.parse and tried to conform to the existing code (e.g. calling back with a string as an error).
