### PR TITLE
Handle node http errors

### DIFF
--- a/webpurify.js
+++ b/webpurify.js
@@ -72,18 +72,20 @@ WebPurify.prototype.request = function(host, path, method, ssl, callback) {
         base_type = https;
     }
     var req = base_type.request(options, function(res) {
-        res.on('data', function(data) {
+        var chunks = [];
+        res.on('data', function(chunk) {
+            chunks.push(chunk);
+        });
+        res.on('end', function() {
             try {
-                data = JSON.parse(data);
+                callback(null, JSON.parse(Buffer.concat(chunks)));
             } catch (e) {
-                return callback("Invalid JSON");
+                callback(e, null);
             }
-
-            callback(null, data);
         });
     });
     req.on('error', function(error) {
-        callback(error.message, null);
+        callback(error, null);
     });
     req.end();
 };

--- a/webpurify.js
+++ b/webpurify.js
@@ -173,7 +173,7 @@ WebPurify.prototype.check = function(text, options, callback) {
         if (err) {
             callback(err, null);
         } else {
-            callback(null, res.found === '1' ? true : false);
+            callback(null, res.found === '1');
         }
     });
 };
@@ -301,7 +301,7 @@ WebPurify.prototype.addToBlacklist = function(word, deep_search, callback) {
             if (err) {
                 callback(err,null);
             } else {
-                callback(null, res.success === '1' ? true : false);
+                callback(null, res.success === '1');
             }
         }
     });
@@ -323,7 +323,7 @@ WebPurify.prototype.removeFromBlacklist = function(word, callback) {
             if (err) {
                 callback(err,null);
             } else {
-                callback(null, res.success === '1' ? true : false);
+                callback(null, res.success === '1');
             }
         }
     });
@@ -375,7 +375,7 @@ WebPurify.prototype.addToWhitelist = function(word, callback) {
             if (err) {
                 callback(err,null);
             } else {
-                callback(null, res.success === '1' ? true : false);
+                callback(null, res.success === '1');
             }
         }
     });
@@ -397,7 +397,7 @@ WebPurify.prototype.removeFromWhitelist = function(word, callback) {
             if (err) {
                 callback(err,null);
             } else {
-                callback(null, res.success === '1' ? true : false);
+                callback(null, res.success === '1');
             }
         }
     });


### PR DESCRIPTION
This module was never calling the user provided callback in certain cases. There was also a possibility that it would try to parse an incomplete response body from the api. Finally, I made all the error handling use javascript Error instances. I modeled the error handling after this code: https://github.com/mileszim/webpurify-gem/blob/master/lib/web_purify/request.rb#L54

We have been seeing this error in our production environment:
```
error TypeError: Cannot read property 'stat' of undefined
    at /var/app/current/node_modules/webpurify/webpurify.js:116:44
...
```
Which would have happened in the old code if the rsp['@attributes'] was undefined. That doesn't seem possible from reading the API docs online, so it might have been due to a potential incomplete body being parsed.